### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,16 +10,16 @@ BTR	KEYWORD1
 # Methods and Functions 
 #######################################	
 
-begin			KEYWORD2
-upaliLED		KEYWORD2
-duga			KEYWORD2
-cirkus			KEYWORD2
-temp			KEYWORD2
+begin	KEYWORD2
+upaliLED	KEYWORD2
+duga	KEYWORD2
+cirkus	KEYWORD2
+temp	KEYWORD2
 postaviJacinu	KEYWORD2
-poti            KEYWORD2
-potiV           KEYWORD2
-ugasiLED        KEYWORD2
-ldr             KEYWORD2
+poti	KEYWORD2
+potiV	KEYWORD2
+ugasiLED	KEYWORD2
+ldr	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords